### PR TITLE
Replace wp_mock with brain/monkey

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 vendor/
+composer.lock

--- a/composer.json
+++ b/composer.json
@@ -19,5 +19,10 @@
     },
     "autoload": {
         "classmap": ["src/"]
+    },
+    "config": {
+        "allow-plugins": {
+            "composer/installers": true
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,6 @@
         "ssnepenthe/wp-requirements": "^0.1"
     },
     "require-dev": {
-        "10up/wp_mock": "dev-dev",
         "mockery/mockery": "^0.9",
         "psy/psysh": "^0.8"
     },

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
         "ssnepenthe/wp-requirements": "^0.1"
     },
     "require-dev": {
+        "brain/monkey": "^2.0",
         "mockery/mockery": "^0.9",
         "psy/psysh": "^0.8"
     },

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,6 @@
     },
     "require-dev": {
         "brain/monkey": "^2.0",
-        "mockery/mockery": "^0.9",
         "psy/psysh": "^0.8"
     },
     "autoload": {

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -1,6 +1,3 @@
 <?php
 
 require_once __DIR__ . '/../../vendor/autoload.php';
-
-WP_Mock::activateStrictMode();
-WP_Mock::bootstrap();

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -1,3 +1,5 @@
 <?php
 
 require_once __DIR__ . '/../../vendor/autoload.php';
+
+define( 'ABSPATH', __DIR__ );

--- a/tests/unit/test-options-store.php
+++ b/tests/unit/test-options-store.php
@@ -1,88 +1,84 @@
 <?php
 
+use Brain\Monkey;
+use Brain\Monkey\Functions;
 use WP_Hashids\Options_Store;
 
 class Options_Store_Test extends PHPUnit_Framework_TestCase {
 	protected $store;
 
 	function setUp() {
-		WP_Mock::setUp();
+		parent::setUp();
+		Monkey\setUp();
 
 		$this->store = new Options_Store;
 	}
 
 	function tearDown() {
-		WP_Mock::tearDown();
-
 		$this->store = null;
+
+		Monkey\tearDown();
+		parent::tearDown();
 	}
 
 	/** @test */
 	function add_delegates_to_add_option() {
-		WP_Mock::userFunction( 'add_option', [
-			'args' => [ 'test', 'value' ],
-			'times' => 1,
-			'return' => true,
-		] );
+		Functions\expect( 'add_option' )
+			->once()
+			->with( 'test', 'value' )
+			->andReturn( true );
 
 		$this->assertTrue( $this->store->add( 'test', 'value' ) );
 	}
 
 	/** @test */
 	function delete_delegates_to_delete_option() {
-		WP_Mock::userFunction( 'delete_option', [
-			'args' => 'test',
-			'times' => 1,
-			'return' => true,
-		] );
+		Functions\expect( 'delete_option' )
+			->once()
+			->with( 'test' )
+			->andReturn( true );
 
 		$this->assertTrue( $this->store->delete( 'test' ) );
 	}
 
 	/** @test */
 	function get_delegates_to_get_option() {
-		WP_Mock::userFunction( 'get_option', [
-			'args' => 'test',
-			'times' => 1,
-			'return' => 'value',
-		] );
+		Functions\expect( 'get_option' )
+			->once()
+			->with( 'test' )
+			->andReturn( 'value' );
 
 		$this->assertEquals( 'value', $this->store->get( 'test' ) );
 	}
 
 	/** @test */
 	function set_delegates_to_update_option() {
-		WP_Mock::userFunction( 'update_option', [
-			'args' => [ 'test', 'value' ],
-			'times' => 1,
-			'return' => true,
-		] );
+		Functions\expect( 'update_option' )
+			->once()
+			->with( 'test', 'value' )
+			->andReturn( true );
 
 		$this->assertTrue( $this->store->set( 'test', 'value' ) );
 	}
 
 	/** @test */
 	function it_prepends_prefix_to_option_key_if_applicable() {
-		WP_Mock::userFunction( 'add_option', [
-			'args' => [ 'pfx_test', 'value' ],
-			'times' => 1,
-			'return' => true,
-		] );
-		WP_Mock::userFunction( 'delete_option', [
-			'args' => 'pfx_test',
-			'times' => 1,
-			'return' => true,
-		] );
-		WP_Mock::userFunction( 'get_option', [
-			'args' => 'pfx_test',
-			'times' => 1,
-			'return' => 'value',
-		] );
-		WP_Mock::userFunction( 'update_option', [
-			'args' => [ 'pfx_test', 'value' ],
-			'times' => 1,
-			'return' => true,
-		] );
+		Functions\expect( 'add_option' )
+			->once()
+			->with( 'pfx_test', 'value' )
+			->andReturn( true );
+		Functions\expect( 'delete_option' )
+			->once()
+			->with( 'pfx_test' )
+			->andReturn( true );
+		Functions\expect( 'get_option' )
+			->once()
+			->with( 'pfx_test' )
+			->andReturn( 'value' );
+		Functions\expect( 'update_option' )
+			->once()
+			->with( 'pfx_test', 'value' )
+			->andReturn( true );
 
 		$prefixed_store = new Options_Store( 'pfx' );
 


### PR DESCRIPTION
WP_Mock@dev-dev no longer exists and was preventing composer from being able to install this plugin.

WP_Mock usage was minimal, so I opted to replace with brain/monkey as that is my preferred tool these days.

Closes #7.